### PR TITLE
Change syntax order with tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ microc.native :
 clean :
 	ocamlbuild -clean
 	rm -rf testall.log *.diff microc scanner.ml parser.ml parser.mli
-	rm -rf *.cmx *.cmi *.cmo *.cmx *.o *.ll
+	rm -rf *.cmx *.cmi *.cmo *.cmx *.o *.ll *.err
 
 # More detailed: build using ocamlc/ocamlopt + ocamlfind to locate LLVM
 

--- a/parser.mly
+++ b/parser.mly
@@ -39,10 +39,10 @@ decls:
  | decls fdecl { fst $1, ($2 :: snd $1) }
 
 fdecl:
-   FUNCTION typ ID LPAREN formals_opt RPAREN LBRACE vdecl_list stmt_list RBRACE
-     { { typ = $2;
-	 fname = $3;
-	 formals = $5;
+   FUNCTION ID LPAREN formals_opt RPAREN typ LBRACE vdecl_list stmt_list RBRACE
+     { { typ = $6;
+	 fname = $2;
+	 formals = $4;
 	 locals = List.rev $8;
 	 body = List.rev $9 } }
 
@@ -51,8 +51,8 @@ formals_opt:
   | formal_list   { List.rev $1 }
 
 formal_list:
-    typ ID                   { [($1,$2)] }
-  | formal_list COMMA typ ID { ($3,$4) :: $1 }
+    ID typ                   { [($2,$1)] }
+  | formal_list COMMA ID typ { ($4,$3) :: $1 }
 
 typ:
     INT { Int }
@@ -65,7 +65,7 @@ vdecl_list:
   | vdecl_list vdecl { $2 :: $1 }
 
 vdecl:
-   typ ID SEMI { ($1, $2) }
+   ID typ SEMI { ($2, $1) }
 
 stmt_list:
     /* nothing */  { [] }

--- a/parser.mly
+++ b/parser.mly
@@ -8,7 +8,7 @@ open Ast
 %token SEMI LPAREN RPAREN LBRACE RBRACE COMMA
 %token PLUS MINUS TIMES DIVIDE ASSIGN NOT
 %token EQ NEQ LT LEQ GT GEQ TRUE FALSE AND OR
-%token RETURN IF ELSE FOR INT BOOL VOID STRTYPE FUNCTION
+%token LET RETURN IF ELSE FOR INT BOOL VOID STRTYPE FUNCTION
 %token <string> STRING
 %token <int> LITERAL
 %token <string> ID
@@ -65,7 +65,7 @@ vdecl_list:
   | vdecl_list vdecl { $2 :: $1 }
 
 vdecl:
-   ID typ SEMI { ($2, $1) }
+   LET ID typ SEMI { ($3, $2) }
 
 stmt_list:
     /* nothing */  { [] }

--- a/scanner.mll
+++ b/scanner.mll
@@ -37,6 +37,7 @@ rule token = parse
 | "string" { STRTYPE }
 | "false"  { FALSE }
 | "function" { FUNCTION }
+| "let"      { LET }
 | ['0'-'9']+ as lxm { LITERAL(int_of_string lxm) }
 | ['a'-'z' 'A'-'Z']['a'-'z' 'A'-'Z' '0'-'9' '_']* as lxm { ID(lxm) }
 | '"'      { read_string (Buffer.create 17) lexbuf }

--- a/tests/fail-assign1.mc
+++ b/tests/fail-assign1.mc
@@ -1,11 +1,11 @@
-function int main()
+function main() int
 {
-  int i;
-  bool b;
+  i int;
+  b bool;
 
   i = 42;
   i = 10;
   b = true;
   b = false;
-  i = false; /* Fail: assigning a bool to an integer */
+  i = false; /* Fail: assigning a to bool an integer */
 }

--- a/tests/fail-assign1.mc
+++ b/tests/fail-assign1.mc
@@ -1,7 +1,7 @@
 function main() int
 {
-  i int;
-  b bool;
+  let i int;
+  let b bool;
 
   i = 42;
   i = 10;

--- a/tests/fail-assign2.mc
+++ b/tests/fail-assign2.mc
@@ -1,7 +1,7 @@
-function int main()
+function main() int
 {
-  int i;
-  bool b;
+  i int;
+  b bool;
 
   b = 48; /* Fail: assigning an integer to a bool */
 }

--- a/tests/fail-assign2.mc
+++ b/tests/fail-assign2.mc
@@ -1,7 +1,7 @@
 function main() int
 {
-  i int;
-  b bool;
+  let i int;
+  let b bool;
 
   b = 48; /* Fail: assigning an integer to a bool */
 }

--- a/tests/fail-assign3.mc
+++ b/tests/fail-assign3.mc
@@ -1,11 +1,11 @@
-function void myvoid()
+function myvoid() void
 {
   return;
 }
 
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
-  i = myvoid(); /* Fail: assigning a void to an integer */
+  i = myvoid(); /* Fail: assigning a to void an integer */
 }

--- a/tests/fail-assign3.mc
+++ b/tests/fail-assign3.mc
@@ -5,7 +5,7 @@ function myvoid() void
 
 function main() int
 {
-  i int;
+  let i int;
 
   i = myvoid(); /* Fail: assigning a to void an integer */
 }

--- a/tests/fail-dead1.mc
+++ b/tests/fail-dead1.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;  
+  let i int;
 
   i = 15;
   return i;

--- a/tests/fail-dead1.mc
+++ b/tests/fail-dead1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;  
+  i int;  
 
   i = 15;
   return i;

--- a/tests/fail-dead2.mc
+++ b/tests/fail-dead2.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;  
+  let i int;
 
   {
     i = 15;

--- a/tests/fail-dead2.mc
+++ b/tests/fail-dead2.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;  
+  i int;  
 
   {
     i = 15;

--- a/tests/fail-expr1.mc
+++ b/tests/fail-expr1.mc
@@ -1,10 +1,10 @@
-a int;
-b bool;
+let a int;
+let b bool;
 
 function foo(c int, d bool) void
 {
-  dd int;
-  e bool;
+  let dd int;
+  let e bool;
   a + c;
   c - a;
   a * 3;

--- a/tests/fail-expr1.mc
+++ b/tests/fail-expr1.mc
@@ -1,10 +1,10 @@
-int a;
-bool b;
+a int;
+b bool;
 
-function void foo(int c, bool d)
+function foo(c int, d bool) void
 {
-  int dd;
-  bool e;
+  dd int;
+  e bool;
   a + c;
   c - a;
   a * 3;
@@ -12,7 +12,7 @@ function void foo(int c, bool d)
   d + a; /* Error: bool + int */
 }
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-expr2.mc
+++ b/tests/fail-expr2.mc
@@ -1,10 +1,10 @@
-a int;
-b bool;
+let a int;
+let b bool;
 
 function foo(c int, d bool) void
 {
-  d int;
-  e bool;
+  let d int;
+  let e bool;
   b + a; /* Error: bool + int */
 }
 

--- a/tests/fail-expr2.mc
+++ b/tests/fail-expr2.mc
@@ -1,14 +1,14 @@
-int a;
-bool b;
+a int;
+b bool;
 
-function void foo(int c, bool d)
+function foo(c int, d bool) void
 {
-  int d;
-  bool e;
+  d int;
+  e bool;
   b + a; /* Error: bool + int */
 }
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-for-as-while1.mc
+++ b/tests/fail-for-as-while1.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
 
   for (true) {
     i = i + 1;

--- a/tests/fail-for-as-while1.mc
+++ b/tests/fail-for-as-while1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
   for (true) {
     i = i + 1;

--- a/tests/fail-for-as-while2.mc
+++ b/tests/fail-for-as-while2.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
 
   for (true) {
     i = i + 1;

--- a/tests/fail-for-as-while2.mc
+++ b/tests/fail-for-as-while2.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
   for (true) {
     i = i + 1;

--- a/tests/fail-for1.mc
+++ b/tests/fail-for1.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
   for ( ; true ; ) {} /* OK: Forever */
 
   for (i = 0 ; i < 10 ; i = i + 1) {

--- a/tests/fail-for1.mc
+++ b/tests/fail-for1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
   for ( ; true ; ) {} /* OK: Forever */
 
   for (i = 0 ; i < 10 ; i = i + 1) {

--- a/tests/fail-for2.mc
+++ b/tests/fail-for2.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
   for (i = 0; j < 10 ; i = i + 1) {} /* j undefined */
 

--- a/tests/fail-for2.mc
+++ b/tests/fail-for2.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
 
   for (i = 0; j < 10 ; i = i + 1) {} /* j undefined */
 

--- a/tests/fail-for3.mc
+++ b/tests/fail-for3.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
   for (i = 0; i ; i = i + 1) {} /* i is an integer, not Boolean */
 

--- a/tests/fail-for3.mc
+++ b/tests/fail-for3.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
 
   for (i = 0; i ; i = i + 1) {} /* i is an integer, not Boolean */
 

--- a/tests/fail-for4.mc
+++ b/tests/fail-for4.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
 
   for (i = 0; i < 10 ; i = j + 1) {} /* j undefined */
 

--- a/tests/fail-for4.mc
+++ b/tests/fail-for4.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
   for (i = 0; i < 10 ; i = j + 1) {} /* j undefined */
 

--- a/tests/fail-for5.mc
+++ b/tests/fail-for5.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
 
   for (i = 0; i < 10 ; i = i + 1) {
     foo(); /* Error: no function foo */

--- a/tests/fail-for5.mc
+++ b/tests/fail-for5.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
 
   for (i = 0; i < 10 ; i = i + 1) {
     foo(); /* Error: no function foo */

--- a/tests/fail-func1.mc
+++ b/tests/fail-func1.mc
@@ -1,12 +1,12 @@
-function int foo() {}
+function foo() int {}
 
-function int bar() {}
+function bar() int {}
 
-function int baz() {}
+function baz() int {}
 
-function void bar() {} /* Error: duplicate function bar */
+function bar() void {} /* Error: duplicate function bar */
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-func2.mc
+++ b/tests/fail-func2.mc
@@ -1,8 +1,8 @@
-function int foo(int a, bool b, int c) { }
+function foo(a int, b bool, c int) int { }
 
-function void bar(int a, bool b, int a) {} /* Error: duplicate formal a in bar */
+function bar(a int, b bool, a int) void {} /* Error: duplicate formal a in bar */
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-func3.mc
+++ b/tests/fail-func3.mc
@@ -1,8 +1,8 @@
-function int foo(int a, bool b, int c) { }
+function foo(a int, b bool, c int) int { }
 
-function void bar(int a, void b, int c) {} /* Error: illegal void formal b */
+function bar(a int, b void, c int) void {} /* Error: illegal formal void b */
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-func4.mc
+++ b/tests/fail-func4.mc
@@ -1,12 +1,12 @@
-function int foo() {}
+function foo() int {}
 
-function void bar() {}
+function bar() void {}
 
-function int print() {} /* Should not be able to define print_int */
+function print() int {} /* Should not be able to define print */
 
-function void baz() {}
+function baz() void {}
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-func5.mc
+++ b/tests/fail-func5.mc
@@ -1,14 +1,14 @@
-function int foo() {}
+function foo() int {}
 
-function int bar() {
-  int a;
-  void b; /* Error: illegal void local b */
-  bool c;
+function bar() int {
+  a int;
+  b void; /* Error: illegal local void b */
+  c bool;
 
   return 0;
 }
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-func5.mc
+++ b/tests/fail-func5.mc
@@ -1,9 +1,9 @@
 function foo() int {}
 
 function bar() int {
-  a int;
-  b void; /* Error: illegal local void b */
-  c bool;
+  let a int;
+  let b void; /* Error: illegal local void b */
+  let c bool;
 
   return 0;
 }

--- a/tests/fail-func6.mc
+++ b/tests/fail-func6.mc
@@ -1,8 +1,8 @@
-function void foo(int a, bool b)
+function foo(a int, b bool) void
 {
 }
 
-function int main()
+function main() int
 {
   foo(42, true);
   foo(42); /* Wrong number of arguments */

--- a/tests/fail-func7.mc
+++ b/tests/fail-func7.mc
@@ -1,8 +1,8 @@
-function void foo(int a, bool b)
+function foo(a int, b bool) void
 {
 }
 
-function int main()
+function main() int
 {
   foo(42, true);
   foo(42, true, false); /* Wrong number of arguments */

--- a/tests/fail-func8.mc
+++ b/tests/fail-func8.mc
@@ -1,13 +1,13 @@
-function void foo(int a, bool b)
+function foo(a int, b bool) void
 {
 }
 
-function void bar()
+function bar() void
 {
 }
 
-function int main()
+function main() int
 {
   foo(42, true);
-  foo(42, bar()); /* int and void, not int and bool */
+  foo(42, bar()); /* and int void, not and int bool */
 }

--- a/tests/fail-func9.mc
+++ b/tests/fail-func9.mc
@@ -1,8 +1,8 @@
-function void foo(int a, bool b)
+function foo(a int, b bool) void
 {
 }
 
-function int main()
+function main() int
 {
   foo(42, true);
   foo(42, 42); /* Fail: int, not bool */

--- a/tests/fail-global1.mc
+++ b/tests/fail-global1.mc
@@ -1,6 +1,6 @@
-c int;
-b bool;
-a void; /* global variables should not be void */
+let c int;
+let b bool;
+let a void; /* global variables should not be void */
 
 
 function main() int

--- a/tests/fail-global1.mc
+++ b/tests/fail-global1.mc
@@ -1,9 +1,9 @@
-int c;
-bool b;
-void a; /* global variables should not be void */
+c int;
+b bool;
+a void; /* global variables should not be void */
 
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-global2.mc
+++ b/tests/fail-global2.mc
@@ -1,9 +1,9 @@
-int b;
-bool c;
-int a;
-int b; /* Duplicate global variable */
+b int;
+c bool;
+a int;
+b int; /* Duplicate global variable */
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/fail-global2.mc
+++ b/tests/fail-global2.mc
@@ -1,7 +1,7 @@
-b int;
-c bool;
-a int;
-b int; /* Duplicate global variable */
+let b int;
+let c bool;
+let a int;
+let b int; /* Duplicate global variable */
 
 function main() int
 {

--- a/tests/fail-if1.mc
+++ b/tests/fail-if1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
   if (true) {}
   if (false) {} else {}
-  if (42) {} /* Error: non-bool predicate */
+  if (42) {} /* Error: non-predicate bool */
 }

--- a/tests/fail-if2.mc
+++ b/tests/fail-if2.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   if (true) {
     foo; /* Error: undeclared variable */

--- a/tests/fail-if3.mc
+++ b/tests/fail-if3.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   if (true) {
     42;

--- a/tests/fail-return1.mc
+++ b/tests/fail-return1.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   return true; /* Should return int */
 }

--- a/tests/fail-return2.mc
+++ b/tests/fail-return2.mc
@@ -1,10 +1,10 @@
-function void foo()
+function foo() void
 {
   if (true) return 42; /* Should return void */
   else return;
 }
 
-function int main()
+function main() int
 {
   return 42;
 }

--- a/tests/test-arith1.mc
+++ b/tests/test-arith1.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   print_int(39 + 3);
   return 0;

--- a/tests/test-arith2.mc
+++ b/tests/test-arith2.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   print_int(1 + 2 * 3 + 4);
   return 0;

--- a/tests/test-arith3.mc
+++ b/tests/test-arith3.mc
@@ -5,7 +5,7 @@ function foo(a int) int
 
 function main() int
 {
-  a int;
+  let a int;
   a = 42;
   a = a + 5;
   print_int(a);

--- a/tests/test-arith3.mc
+++ b/tests/test-arith3.mc
@@ -1,11 +1,11 @@
-function int foo(int a)
+function foo(a int) int
 {
   return a;
 }
 
-function int main()
+function main() int
 {
-  int a;
+  a int;
   a = 42;
   a = a + 5;
   print_int(a);

--- a/tests/test-fib.mc
+++ b/tests/test-fib.mc
@@ -1,10 +1,10 @@
-function int fib(int x)
+function fib(x int) int
 {
   if (x < 2) return 1;
   return fib(x-1) + fib(x-2);
 }
 
-function int main()
+function main() int
 {
   print_int(fib(0));
   print_int(fib(1));

--- a/tests/test-for-as-while1.mc
+++ b/tests/test-for-as-while1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
   i = 5;
   for (i > 0) {
     print_int(i);

--- a/tests/test-for-as-while1.mc
+++ b/tests/test-for-as-while1.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
   i = 5;
   for (i > 0) {
     print_int(i);

--- a/tests/test-for1.mc
+++ b/tests/test-for1.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
   for (i = 0 ; i < 5 ; i = i + 1) {
     print_int(i);
   }

--- a/tests/test-for1.mc
+++ b/tests/test-for1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
   for (i = 0 ; i < 5 ; i = i + 1) {
     print_int(i);
   }

--- a/tests/test-for2.mc
+++ b/tests/test-for2.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  i int;
+  let i int;
   i = 0;
   for ( ; i < 5; ) {
     print_int(i);

--- a/tests/test-for2.mc
+++ b/tests/test-for2.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int i;
+  i int;
   i = 0;
   for ( ; i < 5; ) {
     print_int(i);

--- a/tests/test-func1.mc
+++ b/tests/test-func1.mc
@@ -5,7 +5,7 @@ function add(a int, b int) int
 
 function main() int
 {
-  a int;
+  let a int;
   a = add(39, 3);
   print_int(a);
   return 0;

--- a/tests/test-func1.mc
+++ b/tests/test-func1.mc
@@ -1,11 +1,11 @@
-function int add(int a, int b)
+function add(a int, b int) int
 {
   return a + b;
 }
 
-function int main()
+function main() int
 {
-  int a;
+  a int;
   a = add(39, 3);
   print_int(a);
   return 0;

--- a/tests/test-func2.mc
+++ b/tests/test-func2.mc
@@ -7,7 +7,7 @@ function fun(x int, y int) int
 
 function main() int
 {
-  i int;
+  let i int;
   i = 1;
 
   fun(i = 2, i = i+1);

--- a/tests/test-func2.mc
+++ b/tests/test-func2.mc
@@ -1,13 +1,13 @@
 /* Bug noticed by Pin-Chin Huang */
 
-function int fun(int x, int y)
+function fun(x int, y int) int
 {
   return 0;
 }
 
-function int main()
+function main() int
 {
-  int i;
+  i int;
   i = 1;
 
   fun(i = 2, i = i+1);

--- a/tests/test-func3.mc
+++ b/tests/test-func3.mc
@@ -1,4 +1,4 @@
-function void print_intem(int a, int b, int c, int d)
+function print_intem(a int, b int, c int, d int) void
 {
   print_int(a);
   print_int(b);
@@ -6,7 +6,7 @@ function void print_intem(int a, int b, int c, int d)
   print_int(d);
 }
 
-function int main()
+function main() int
 {
   print_intem(42,17,192,8);
   return 0;

--- a/tests/test-func4.mc
+++ b/tests/test-func4.mc
@@ -1,13 +1,13 @@
-function int add(int a, int b)
+function add(a int, b int) int
 {
-  int c;
+  c int;
   c = a + b;
   return c;
 }
 
-function int main()
+function main() int
 {
-  int d;
+  d int;
   d = add(52, 10);
   print_int(d);
   return 0;

--- a/tests/test-func4.mc
+++ b/tests/test-func4.mc
@@ -1,13 +1,13 @@
 function add(a int, b int) int
 {
-  c int;
+  let c int;
   c = a + b;
   return c;
 }
 
 function main() int
 {
-  d int;
+  let d int;
   d = add(52, 10);
   print_int(d);
   return 0;

--- a/tests/test-func5.mc
+++ b/tests/test-func5.mc
@@ -1,9 +1,9 @@
-function int foo(int a)
+function foo(a int) int
 {
   return a;
 }
 
-function int main()
+function main() int
 {
   return 0;
 }

--- a/tests/test-gcd.mc
+++ b/tests/test-gcd.mc
@@ -1,4 +1,4 @@
-function int gcd(int a, int b) {
+function gcd(a int, b int) int {
   for (a != b) {
     if (a > b) a = a - b;
     else b = b - a;
@@ -6,7 +6,7 @@ function int gcd(int a, int b) {
   return a;
 }
 
-function int main()
+function main() int
 {
   print_int(gcd(2,14));
   print_int(gcd(3,15));

--- a/tests/test-gcd2.mc
+++ b/tests/test-gcd2.mc
@@ -1,11 +1,11 @@
-function int gcd(int a, int b) {
+function gcd(a int, b int) int {
   for (a != b)
     if (a > b) a = a - b;
     else b = b - a;
   return a;
 }
 
-function int main()
+function main() int
 {
   print_int(gcd(14,21));
   print_int(gcd(8,36));

--- a/tests/test-global1.mc
+++ b/tests/test-global1.mc
@@ -1,23 +1,23 @@
-int a;
-int b;
+a int;
+b int;
 
-function void print_inta()
+function print_inta() void
 {
   print_int(a);
 }
 
-function void print_intb()
+function print_intb() void
 {
   print_int(b);
 }
 
-function void incab()
+function incab() void
 {
   a = a + 1;
   b = b + 1;
 }
 
-function int main()
+function main() int
 {
   a = 42;
   b = 21;

--- a/tests/test-global1.mc
+++ b/tests/test-global1.mc
@@ -1,5 +1,5 @@
-a int;
-b int;
+let a int;
+let b int;
 
 function print_inta() void
 {

--- a/tests/test-global2.mc
+++ b/tests/test-global2.mc
@@ -1,8 +1,8 @@
-i bool;
+let i bool;
 
 function main() int
 {
-  i int; /* Should hide the global i */
+  let i int; /* Should hide the global i */
 
   i = 42;
   print_int(i + i);

--- a/tests/test-global2.mc
+++ b/tests/test-global2.mc
@@ -1,8 +1,8 @@
-bool i;
+i bool;
 
-function int main()
+function main() int
 {
-  int i; /* Should hide the global i */
+  i int; /* Should hide the global i */
 
   i = 42;
   print_int(i + i);

--- a/tests/test-hello.mc
+++ b/tests/test-hello.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   print_int(42);
   print_int(71);

--- a/tests/test-helloworld-assign.mc
+++ b/tests/test-helloworld-assign.mc
@@ -1,6 +1,6 @@
 function int main()
 {
-  let string x;
+  let x string;
   x = "hello world\n"; 
   print(x);
   return 0;

--- a/tests/test-helloworld-assign.mc
+++ b/tests/test-helloworld-assign.mc
@@ -1,6 +1,6 @@
 function int main()
 {
-  string x;
+  let string x;
   x = "hello world\n"; 
   print(x);
   return 0;

--- a/tests/test-helloworld-assign.mc
+++ b/tests/test-helloworld-assign.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   let x string;
   x = "hello world\n"; 

--- a/tests/test-helloworld.mc
+++ b/tests/test-helloworld.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   print("hello world\n");
   return 0;

--- a/tests/test-if1.mc
+++ b/tests/test-if1.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   if (true) print_int(42);
   print_int(17);

--- a/tests/test-if2.mc
+++ b/tests/test-if2.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   if (true) print_int(42); else print_int(8);
   print_int(17);

--- a/tests/test-if3.mc
+++ b/tests/test-if3.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   if (false) print_int(42);
   print_int(17);

--- a/tests/test-if4.mc
+++ b/tests/test-if4.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   if (false) print_int(42); else print_int(8);
   print_int(17);

--- a/tests/test-local1.mc
+++ b/tests/test-local1.mc
@@ -1,12 +1,12 @@
-function void foo(bool i)
+function foo(i bool) void
 {
-  int i; /* Should hide the formal i */
+  i int; /* Should hide the formal i */
 
   i = 42;
   print_int(i + i);
 }
 
-function int main()
+function main() int
 {
   foo(true);
   return 0;

--- a/tests/test-local1.mc
+++ b/tests/test-local1.mc
@@ -1,6 +1,6 @@
 function foo(i bool) void
 {
-  i int; /* Should hide the formal i */
+  let i int; /* Should hide the formal i */
 
   i = 42;
   print_int(i + i);

--- a/tests/test-ops1.mc
+++ b/tests/test-ops1.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   print_int(1 + 2);
   print_int(1 - 2);

--- a/tests/test-ops2.mc
+++ b/tests/test-ops2.mc
@@ -1,4 +1,4 @@
-function int main()
+function main() int
 {
   printb(true);
   printb(false);

--- a/tests/test-var1.mc
+++ b/tests/test-var1.mc
@@ -1,6 +1,6 @@
-function int main()
+function main() int
 {
-  int a;
+  a int;
   a = 42;
   print_int(a);
   return 0;

--- a/tests/test-var1.mc
+++ b/tests/test-var1.mc
@@ -1,6 +1,6 @@
 function main() int
 {
-  a int;
+  let a int;
   a = 42;
   print_int(a);
   return 0;


### PR DESCRIPTION
Here, we inverted the order of variable declarations to `x int` rather than `int x`, golang style. We added the `let` keyword for this.

All tests are up-to-date and passing.
